### PR TITLE
fix(url): honor Content-Disposition from the GET response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 
 env:
-  GO_VERSION: "1.25.9"
+  GO_VERSION: "1.25.10"
 
 jobs:
   test:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:        # allow manual trigger from the Actions tab
 
 env:
-  GO_VERSION: "1.25.9"
+  GO_VERSION: "1.25.10"
 
 jobs:
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/btraven00/hapiq
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/jlaffaye/ftp v0.2.0

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -145,6 +145,39 @@ func (c *Cache) Put(ctx context.Context, rawURL, tmpPath, sha256hex string) erro
 	return nil
 }
 
+// RecordFilename associates a resolved filename with rawURL. This is best-effort
+// metadata (e.g. from a Content-Disposition header) used to name materialized
+// files on a later cache hit, where no HTTP response is available. A no-op when
+// filename is empty or the URL has no index row yet.
+func (c *Cache) RecordFilename(ctx context.Context, rawURL, filename string) error {
+	if filename == "" {
+		return nil
+	}
+	canonical, err := canonicalizeURL(rawURL)
+	if err != nil {
+		return err
+	}
+	_, err = c.s.setFilename.ExecContext(ctx, filename, canonical)
+	return err
+}
+
+// Filename returns the filename recorded for rawURL via RecordFilename, or ""
+// if none is known (unindexed URL, or recorded before this column existed).
+func (c *Cache) Filename(ctx context.Context, rawURL string) (string, error) {
+	canonical, err := canonicalizeURL(rawURL)
+	if err != nil {
+		return "", err
+	}
+	var fn sql.NullString
+	row := c.s.getFilename.QueryRowContext(ctx, canonical)
+	if err := row.Scan(&fn); err == sql.ErrNoRows {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("cache filename lookup: %w", err)
+	}
+	return fn.String, nil
+}
+
 // Materialize links or copies the blob identified by sha256hex to destPath,
 // using the strategy configured in cfg.LinkStrategy.
 func (c *Cache) Materialize(sha256hex, destPath string) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -39,6 +39,46 @@ func writeTmp(t *testing.T, c *cache.Cache, content []byte) (path, sha256hex str
 	return f.Name(), hex.EncodeToString(h[:])
 }
 
+func TestRecordAndGetFilename(t *testing.T) {
+	c := openTestCache(t)
+	ctx := context.Background()
+
+	const rawURL = "https://example.com/api/access/datafile/6154417"
+	tmpPath, hash := writeTmp(t, c, []byte("zip bytes"))
+	if err := c.Put(ctx, rawURL, tmpPath, hash); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// No filename recorded yet.
+	if fn, err := c.Filename(ctx, rawURL); err != nil || fn != "" {
+		t.Fatalf("Filename before record = (%q, %v), want (\"\", nil)", fn, err)
+	}
+
+	if err := c.RecordFilename(ctx, rawURL, "adamson.zip"); err != nil {
+		t.Fatalf("RecordFilename: %v", err)
+	}
+	fn, err := c.Filename(ctx, rawURL)
+	if err != nil {
+		t.Fatalf("Filename: %v", err)
+	}
+	if fn != "adamson.zip" {
+		t.Errorf("Filename = %q, want %q", fn, "adamson.zip")
+	}
+
+	// Empty filename is a no-op and must not clobber the recorded value.
+	if err := c.RecordFilename(ctx, rawURL, ""); err != nil {
+		t.Fatalf("RecordFilename(\"\"): %v", err)
+	}
+	if fn, _ := c.Filename(ctx, rawURL); fn != "adamson.zip" {
+		t.Errorf("Filename after empty record = %q, want unchanged %q", fn, "adamson.zip")
+	}
+
+	// Unknown URL returns empty, not an error.
+	if fn, err := c.Filename(ctx, "https://example.com/unknown"); err != nil || fn != "" {
+		t.Errorf("Filename(unknown) = (%q, %v), want (\"\", nil)", fn, err)
+	}
+}
+
 func TestPutThenGet(t *testing.T) {
 	c := openTestCache(t)
 	ctx := context.Background()

--- a/pkg/cache/sqlite.go
+++ b/pkg/cache/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
@@ -23,21 +24,24 @@ CREATE TABLE IF NOT EXISTS urls (
   sha256        TEXT NOT NULL REFERENCES blobs(sha256),
   etag          TEXT,
   last_modified TEXT,
-  fetched_at    INTEGER NOT NULL
+  fetched_at    INTEGER NOT NULL,
+  filename      TEXT
 );
 
 CREATE INDEX IF NOT EXISTS urls_by_hash ON urls(sha256);
 `
 
 type dbStmts struct {
-	getByURL   *sql.Stmt
-	insertBlob *sql.Stmt
-	insertURL  *sql.Stmt
-	touchBlob  *sql.Stmt
-	deleteURLs *sql.Stmt
-	deleteBlob *sql.Stmt
-	totalSize  *sql.Stmt
-	listLRU    *sql.Stmt
+	getByURL    *sql.Stmt
+	insertBlob  *sql.Stmt
+	insertURL   *sql.Stmt
+	setFilename *sql.Stmt
+	getFilename *sql.Stmt
+	touchBlob   *sql.Stmt
+	deleteURLs  *sql.Stmt
+	deleteBlob  *sql.Stmt
+	totalSize   *sql.Stmt
+	listLRU     *sql.Stmt
 }
 
 func openDB(dir string) (*sql.DB, *dbStmts, error) {
@@ -66,6 +70,14 @@ func openDB(dir string) (*sql.DB, *dbStmts, error) {
 		return nil, nil, fmt.Errorf("apply schema: %w", err)
 	}
 
+	// Migrate databases created before urls.filename existed. ADD COLUMN is a
+	// no-op error ("duplicate column name") once applied, which we ignore.
+	if _, err := db.Exec(`ALTER TABLE urls ADD COLUMN filename TEXT`); err != nil &&
+		!strings.Contains(err.Error(), "duplicate column name") {
+		_ = db.Close()
+		return nil, nil, fmt.Errorf("migrate urls.filename: %w", err)
+	}
+
 	s, err := prepareStmts(db)
 	if err != nil {
 		_ = db.Close()
@@ -85,6 +97,8 @@ func prepareStmts(db *sql.DB) (*dbStmts, error) {
 		{&s.getByURL, `SELECT b.sha256, b.size FROM urls u JOIN blobs b ON b.sha256 = u.sha256 WHERE u.url = ?`},
 		{&s.insertBlob, `INSERT OR IGNORE INTO blobs(sha256, size, created_at, last_used, ref_count) VALUES(?,?,?,?,0)`},
 		{&s.insertURL, `INSERT OR REPLACE INTO urls(url, sha256, etag, last_modified, fetched_at) VALUES(?,?,?,?,?)`},
+		{&s.setFilename, `UPDATE urls SET filename = ? WHERE url = ?`},
+		{&s.getFilename, `SELECT filename FROM urls WHERE url = ?`},
 		{&s.touchBlob, `UPDATE blobs SET last_used = ? WHERE sha256 = ?`},
 		{&s.deleteURLs, `DELETE FROM urls WHERE sha256 = ?`},
 		{&s.deleteBlob, `DELETE FROM blobs WHERE sha256 = ?`},
@@ -105,6 +119,7 @@ func prepareStmts(db *sql.DB) (*dbStmts, error) {
 func (s *dbStmts) close() {
 	for _, stmt := range []*sql.Stmt{
 		s.getByURL, s.insertBlob, s.insertURL,
+		s.setFilename, s.getFilename,
 		s.touchBlob, s.deleteURLs, s.deleteBlob,
 		s.totalSize, s.listLRU,
 	} {

--- a/pkg/downloaders/common/fetch.go
+++ b/pkg/downloaders/common/fetch.go
@@ -64,10 +64,14 @@ func Fetch(ctx context.Context, rawURL, destPath string, opts FetchOptions) (Fet
 			if err := c.Materialize(hash, destPath); err != nil {
 				return FetchResult{}, fmt.Errorf("materialize: %w", err)
 			}
+			// No HTTP response on a hit; recover the filename recorded at store time
+			// so callers can still name the file by its Content-Disposition.
+			cachedName, _ := c.Filename(ctx, rawURL)
 			return FetchResult{
-				SHA256: hash,
-				N:      size,
-				Hit:    true,
+				SHA256:   hash,
+				N:        size,
+				Filename: cachedName,
+				Hit:      true,
 			}, nil
 		}
 	}
@@ -103,6 +107,9 @@ func Fetch(ctx context.Context, rawURL, destPath string, opts FetchOptions) (Fet
 			_ = os.Remove(tmpPath)
 			return directFetch(ctx, client, rawURL, destPath, opts.ExtraHeaders)
 		}
+
+		// Persist the resolved filename so a later cache hit can reproduce it.
+		_ = c.RecordFilename(ctx, rawURL, filename)
 
 		if err := c.Materialize(sha256hex, destPath); err != nil {
 			return FetchResult{}, fmt.Errorf("materialize: %w", err)

--- a/pkg/downloaders/common/fetch.go
+++ b/pkg/downloaders/common/fetch.go
@@ -6,9 +6,11 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/btraven00/hapiq/pkg/cache"
 )
@@ -27,6 +29,12 @@ type FetchResult struct {
 	ContentType string
 	// SHA256 is the hex-encoded sha256 of the file content.
 	SHA256 string
+	// Filename is the filename advertised by the GET response's
+	// Content-Disposition header, if any (empty on cache hit or when the
+	// server provides none). Callers may use it to rename the destination,
+	// since the final filename is often only revealed after redirects that a
+	// pre-fetch HEAD request does not expose.
+	Filename string
 	// N is the number of bytes in the file.
 	N int64
 	// Hit is true when the file was served from the local cache.
@@ -68,6 +76,7 @@ func Fetch(ctx context.Context, rawURL, destPath string, opts FetchOptions) (Fet
 	var tmpPath string
 	var sha256hex string
 	var contentType string
+	var filename string
 	var n int64
 
 	if c != nil {
@@ -78,7 +87,7 @@ func Fetch(ctx context.Context, rawURL, destPath string, opts FetchOptions) (Fet
 		}
 		tmpPath = tmpFile.Name()
 
-		n, sha256hex, contentType, err = streamToFile(ctx, client, rawURL, opts.ExtraHeaders, tmpFile)
+		n, sha256hex, contentType, filename, err = streamToFile(ctx, client, rawURL, opts.ExtraHeaders, tmpFile)
 		if closeErr := tmpFile.Close(); closeErr != nil && err == nil {
 			err = closeErr
 		}
@@ -104,7 +113,7 @@ func Fetch(ctx context.Context, rawURL, destPath string, opts FetchOptions) (Fet
 		if err != nil {
 			return FetchResult{}, err
 		}
-		n, sha256hex, contentType, err = streamToFile(ctx, client, rawURL, opts.ExtraHeaders, f)
+		n, sha256hex, contentType, filename, err = streamToFile(ctx, client, rawURL, opts.ExtraHeaders, f)
 		_ = f.Close()
 		if err != nil {
 			_ = os.Remove(destPath)
@@ -115,6 +124,7 @@ func Fetch(ctx context.Context, rawURL, destPath string, opts FetchOptions) (Fet
 	return FetchResult{
 		ContentType: contentType,
 		SHA256:      sha256hex,
+		Filename:    filename,
 		N:           n,
 		Hit:         false,
 	}, nil
@@ -126,21 +136,26 @@ func directFetch(ctx context.Context, client *http.Client, rawURL, destPath stri
 	if err != nil {
 		return FetchResult{}, err
 	}
-	n, sha256hex, ct, err := streamToFile(ctx, client, rawURL, extra, f)
+	n, sha256hex, ct, filename, err := streamToFile(ctx, client, rawURL, extra, f)
 	_ = f.Close()
 	if err != nil {
 		_ = os.Remove(destPath)
 		return FetchResult{}, err
 	}
-	return FetchResult{ContentType: ct, SHA256: sha256hex, N: n}, nil
+	return FetchResult{ContentType: ct, SHA256: sha256hex, Filename: filename, N: n}, nil
 }
 
 // streamToFile makes a GET request and copies the body into w, computing sha256
-// as it goes. Returns (bytes written, sha256hex, Content-Type, error).
-func streamToFile(ctx context.Context, client *http.Client, rawURL string, extra map[string]string, w io.Writer) (int64, string, string, error) {
+// as it goes. Returns (bytes written, sha256hex, Content-Type, filename, error),
+// where filename is parsed from the GET response's Content-Disposition header
+// (empty when the server provides none). The GET response is authoritative: it
+// reflects the final hop after any redirects, which a pre-fetch HEAD often does
+// not (e.g. storage backends that only set Content-Disposition on the redirect
+// target).
+func streamToFile(ctx context.Context, client *http.Client, rawURL string, extra map[string]string, w io.Writer) (int64, string, string, string, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", rawURL, http.NoBody)
 	if err != nil {
-		return 0, "", "", err
+		return 0, "", "", "", err
 	}
 	for k, v := range extra {
 		req.Header.Set(k, v)
@@ -148,20 +163,29 @@ func streamToFile(ctx context.Context, client *http.Client, rawURL string, extra
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, "", "", err
+		return 0, "", "", "", err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, "", "", fmt.Errorf("HTTP %d for %s", resp.StatusCode, rawURL)
+		return 0, "", "", "", fmt.Errorf("HTTP %d for %s", resp.StatusCode, rawURL)
 	}
 
 	h := sha256.New()
 	n, err := io.Copy(io.MultiWriter(w, h), resp.Body)
 	if err != nil {
-		return 0, "", "", fmt.Errorf("read body: %w", err)
+		return 0, "", "", "", fmt.Errorf("read body: %w", err)
 	}
 
-	return n, hex.EncodeToString(h.Sum(nil)), resp.Header.Get("Content-Type"), nil
+	filename := FilenameFromContentDisposition(resp.Header.Get("Content-Disposition"))
+	return n, hex.EncodeToString(h.Sum(nil)), resp.Header.Get("Content-Type"), filename, nil
 }
 
+// FilenameFromContentDisposition extracts the filename parameter from a
+// Content-Disposition header value, returning "" if absent or unparseable.
+func FilenameFromContentDisposition(cd string) string {
+	if _, params, err := mime.ParseMediaType(cd); err == nil {
+		return strings.TrimSpace(params["filename"])
+	}
+	return ""
+}

--- a/pkg/downloaders/url/downloader.go
+++ b/pkg/downloaders/url/downloader.go
@@ -2,23 +2,21 @@
 // directly from an arbitrary HTTP(S) URL. The "ID" is the URL itself.
 // In manifests use the dedicated url: field:
 //
-//	- identifier: my-file
-//	  url: https://example.com/file.csv
+//   - identifier: my-file
+//     url: https://example.com/file.csv
 package url
 
 import (
 	"context"
 	"fmt"
-	"mime"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	"github.com/btraven00/hapiq/pkg/downloaders"
 	"github.com/btraven00/hapiq/internal/version"
+	"github.com/btraven00/hapiq/pkg/downloaders"
 	"github.com/btraven00/hapiq/pkg/downloaders/common"
 )
 
@@ -144,6 +142,22 @@ func (d *URLDownloader) Download(ctx context.Context, req *downloaders.DownloadR
 		return result, nil
 	}
 
+	// The GET response may reveal a better filename via Content-Disposition than
+	// the pre-fetch HEAD did (common with storage backends that only set the
+	// header on a redirect target). If so, rename the downloaded file to it.
+	if fr.Filename != "" {
+		if better := common.SanitizeFilename(fr.Filename); better != "" && better != filepath.Base(targetPath) {
+			newPath := filepath.Join(req.OutputDir, better)
+			if err := os.Rename(targetPath, newPath); err == nil {
+				targetPath = newPath
+				filename = fr.Filename
+			} else {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("could not rename to %q: %v", better, err))
+			}
+		}
+	}
+
 	fi := downloaders.FileInfo{
 		Path:         targetPath,
 		OriginalName: filename,
@@ -200,12 +214,8 @@ func resolveFilename(ctx context.Context, rawURL string, client *http.Client) st
 	if err == nil {
 		if resp, err := client.Do(req); err == nil {
 			_ = resp.Body.Close()
-			if cd := resp.Header.Get("Content-Disposition"); cd != "" {
-				if _, params, err := mime.ParseMediaType(cd); err == nil {
-					if v := strings.TrimSpace(params["filename"]); v != "" {
-						return v
-					}
-				}
+			if v := common.FilenameFromContentDisposition(resp.Header.Get("Content-Disposition")); v != "" {
+				return v
 			}
 		}
 	}

--- a/pkg/downloaders/url/downloader_test.go
+++ b/pkg/downloaders/url/downloader_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btraven00/hapiq/pkg/cache"
 	"github.com/btraven00/hapiq/pkg/downloaders"
 )
 
@@ -388,6 +389,71 @@ func TestDownload_ContentDispositionOnGET(t *testing.T) {
 	}
 	if len(result.Files) != 1 || filepath.Base(result.Files[0].Path) != "real_name.zip" {
 		t.Errorf("result file path = %+v, want basename real_name.zip", result.Files)
+	}
+}
+
+// TestDownload_ContentDispositionFromCacheHit verifies that the
+// Content-Disposition filename survives a cache hit, where no HTTP GET occurs
+// and the filename must be recovered from the cache index.
+func TestDownload_ContentDispositionFromCacheHit(t *testing.T) {
+	const body = "payload"
+	getCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			getCount++
+			w.Header().Set("Content-Disposition", `attachment; filename="real_name.zip"`)
+			_, _ = w.Write([]byte(body))
+		}
+	}))
+	defer srv.Close()
+
+	c, err := cache.Open(cache.Config{Dir: t.TempDir(), LinkStrategy: cache.StrategyCopy})
+	if err != nil {
+		t.Fatalf("cache.Open: %v", err)
+	}
+	defer c.Close()
+	ctx := cache.WithCache(context.Background(), c)
+
+	d := New(WithTimeout(5 * time.Second))
+	url := srv.URL + "/6154417"
+
+	// First download: cache miss, performs the GET, records the filename.
+	dir1 := t.TempDir()
+	r1, err := d.Download(ctx, &downloaders.DownloadRequest{
+		ID: url, OutputDir: dir1,
+		Options: &downloaders.DownloadOptions{NonInteractive: true},
+	})
+	if err != nil || !r1.Success {
+		t.Fatalf("first Download failed: err=%v result=%+v", err, r1)
+	}
+	if _, err := os.Stat(filepath.Join(dir1, "real_name.zip")); err != nil {
+		t.Fatalf("first download not named from Content-Disposition: %v", err)
+	}
+	if getCount != 1 {
+		t.Fatalf("expected 1 GET on miss, got %d", getCount)
+	}
+
+	// Second download into a fresh dir: cache hit (no GET) must still produce
+	// the Content-Disposition filename, not the URL basename.
+	dir2 := t.TempDir()
+	r2, err := d.Download(ctx, &downloaders.DownloadRequest{
+		ID: url, OutputDir: dir2,
+		Options: &downloaders.DownloadOptions{NonInteractive: true},
+	})
+	if err != nil || !r2.Success {
+		t.Fatalf("second Download failed: err=%v result=%+v", err, r2)
+	}
+	if getCount != 1 {
+		t.Errorf("expected no further GET on cache hit, got %d total", getCount)
+	}
+	if len(r2.Files) != 1 || !r2.Files[0].CacheHit {
+		t.Errorf("expected a cache hit on second download, got %+v", r2.Files)
+	}
+	if _, err := os.Stat(filepath.Join(dir2, "real_name.zip")); err != nil {
+		t.Errorf("cache-hit download not named from Content-Disposition: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir2, "6154417")); err == nil {
+		t.Error("stale URL-basename file should not exist after cache-hit rename")
 	}
 }
 

--- a/pkg/downloaders/url/downloader_test.go
+++ b/pkg/downloaders/url/downloader_test.go
@@ -343,6 +343,54 @@ func TestDownload_NonInteractiveOverwritesExisting(t *testing.T) {
 	}
 }
 
+// TestDownload_ContentDispositionOnGET reproduces the case where the server
+// advertises the real filename only on the GET response (e.g. a storage backend
+// reached via redirect), not on the pre-fetch HEAD. The downloaded file must be
+// named after the Content-Disposition filename, not the URL path basename.
+func TestDownload_ContentDispositionOnGET(t *testing.T) {
+	const body = "payload"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// HEAD intentionally omits Content-Disposition; only GET sets it.
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Disposition", `attachment; filename="real_name.zip"`)
+			_, _ = w.Write([]byte(body))
+		}
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	d := New(WithTimeout(5 * time.Second))
+	req := &downloaders.DownloadRequest{
+		ID:        srv.URL + "/6154417", // extensionless basename, like a Dataverse datafile id
+		OutputDir: dir,
+		Options:   &downloaders.DownloadOptions{NonInteractive: true},
+	}
+
+	result, err := d.Download(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Download() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Download() Success=false, errors: %v", result.Errors)
+	}
+
+	// File should be renamed to the Content-Disposition filename.
+	got, err := os.ReadFile(filepath.Join(dir, "real_name.zip"))
+	if err != nil {
+		t.Fatalf("expected file named after Content-Disposition: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("content = %q, want %q", string(got), body)
+	}
+	// The URL-basename fallback must NOT be left behind.
+	if _, err := os.Stat(filepath.Join(dir, "6154417")); err == nil {
+		t.Error("stale URL-basename file should not exist after rename")
+	}
+	if len(result.Files) != 1 || filepath.Base(result.Files[0].Path) != "real_name.zip" {
+		t.Errorf("result file path = %+v, want basename real_name.zip", result.Files)
+	}
+}
+
 func TestFilenameFromURL(t *testing.T) {
 	tests := []struct {
 		rawURL string


### PR DESCRIPTION
The url downloader resolved the output filename from a pre-fetch HEAD request only. Some servers (e.g. Harvard Dataverse, which redirects api/access/datafile/<id> to presigned S3 with response-content-disposition) expose the real filename only on the GET — and only after the redirect — so HEAD returned nothing and the file was saved under the URL basename (e.g. "6154417" instead of "adamson.zip"). Downstream wrappers that derive an extension from the name then mishandle the extensionless file.

streamToFile now parses Content-Disposition from the authoritative GET response and surfaces it via FetchResult.Filename; the url downloader renames the downloaded file to it when it differs from the HEAD/basename guess. Factored the parsing into common.FilenameFromContentDisposition and reused it in resolveFilename. Adds a regression test (CD on GET, not HEAD).

Known limitation: on a cache hit no GET occurs, so the basename fallback is still used; persisting the resolved name in the cache is left as a follow-up.